### PR TITLE
Phase 1: Rename IndentConfig to WhitespaceConfig

### DIFF
--- a/src/GdWriter.zig
+++ b/src/GdWriter.zig
@@ -22,7 +22,7 @@ allocator: std.mem.Allocator,
 const Options = struct {
     writer: *Writer,
     context: ?Context = null,
-    indent_config: IndentConfig = .default,
+    whitespace_config: WhitespaceConfig = .default,
     allocator: std.mem.Allocator,
 };
 
@@ -32,7 +32,7 @@ pub fn init(options: Options) GdWriter {
         .bytes_written = 0,
         .current_line_start = 0,
         .context = options.context orelse .{},
-        .indent_writer = .init(options.indent_config),
+        .indent_writer = .init(options.whitespace_config),
         .allocator = options.allocator,
     };
 }
@@ -1354,7 +1354,7 @@ const NodeType = enums.GdNodeType;
 const formatter = @import("formatter.zig");
 const @"type" = @import("type.zig");
 const Context = @import("Context.zig");
-const IndentConfig = @import("IndentConfig.zig");
+const WhitespaceConfig = @import("WhitespaceConfig.zig");
 const IndentWriter = @import("IndentWriter.zig");
 
 // ============================================================================

--- a/src/IndentWriter.zig
+++ b/src/IndentWriter.zig
@@ -1,8 +1,8 @@
 const IndentWriter = @This();
 
-config: IndentConfig,
+config: WhitespaceConfig,
 
-pub fn init(config: IndentConfig) IndentWriter {
+pub fn init(config: WhitespaceConfig) IndentWriter {
     return .{ .config = config };
 }
 
@@ -26,5 +26,5 @@ fn writeTabs(self: IndentWriter, writer: *Writer, context: Context) !void {
 const std = @import("std");
 const Writer = std.Io.Writer;
 
-const IndentConfig = @import("IndentConfig.zig");
+const WhitespaceConfig = @import("WhitespaceConfig.zig");
 const Context = @import("Context.zig");

--- a/src/WhitespaceConfig.zig
+++ b/src/WhitespaceConfig.zig
@@ -1,27 +1,27 @@
-const logger = std.log.scoped(.indent_config);
+const logger = std.log.scoped(.whitespace_config);
 
-const IndentConfig = @This();
+const WhitespaceConfig = @This();
 
 /// The style of indentation to use
 style: IndentType = .spaces,
 /// The width of indentation (number of spaces or tab width)
 width: u32 = 4,
 
-pub fn spaces(width: u32) IndentConfig {
+pub fn spaces(width: u32) WhitespaceConfig {
     return .{
         .style = .spaces,
         .width = width,
     };
 }
 
-pub const tabs: IndentConfig = .{
+pub const tabs: WhitespaceConfig = .{
     .style = .tabs,
 };
 
 pub const default = spaces(4);
 
 /// Auto-detect indentation style from source code
-pub fn fromSourceFile(source_file: File) !IndentConfig {
+pub fn fromSourceFile(source_file: File) !WhitespaceConfig {
     logger.debug("Auto-detecting indentation style from source file", .{});
 
     var buf: [1024]u8 = undefined;
@@ -64,13 +64,13 @@ pub fn fromSourceFile(source_file: File) !IndentConfig {
     return .default;
 }
 
-pub fn fromCliConfig(cli_config: CliConfig) ?IndentConfig {
-    const indent_config: ?IndentConfig = if (cli_config.indent_type) |indent_type| switch (indent_type) {
-        .tabs => IndentConfig.tabs,
-        .spaces => IndentConfig.spaces(cli_config.indent_width),
+pub fn fromCli(cli_config: CliConfig) ?WhitespaceConfig {
+    const whitespace_config: ?WhitespaceConfig = if (cli_config.indent_type) |indent_type| switch (indent_type) {
+        .tabs => WhitespaceConfig.tabs,
+        .spaces => WhitespaceConfig.spaces(cli_config.indent_width),
     } else null;
 
-    if (indent_config) |config| {
+    if (whitespace_config) |config| {
         logger.debug("Using indentation style from CLI. Style: {}", .{config.style});
 
         if (config.style == .spaces) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -110,7 +110,7 @@ fn formatFiles() !void {
     var stdout_writer = stdout_file.writer(&buf);
     const writer = &stdout_writer.interface;
 
-    const cli_indent_config: ?IndentConfig = .fromCliConfig(config);
+    const cli_whitespace_config: ?WhitespaceConfig = WhitespaceConfig.fromCli(config);
 
     for (config.files) |path| {
         const file = std.fs.cwd().openFile(path, .{}) catch |err| {
@@ -118,7 +118,7 @@ fn formatFiles() !void {
         };
         defer file.close();
 
-        const indent_config = cli_indent_config orelse try IndentConfig.fromSourceFile(file);
+        const whitespace_config = cli_whitespace_config orelse try WhitespaceConfig.fromSourceFile(file);
 
         // Reset file position for parsing
         try file.seekTo(0);
@@ -134,7 +134,7 @@ fn formatFiles() !void {
         var gd_writer = GdWriter.init(.{
             .writer = writer,
             .allocator = arena_allocator,
-            .indent_config = indent_config,
+            .whitespace_config = whitespace_config,
         });
 
         formatter.depthFirstWalk(&cursor, &gd_writer) catch |err| {
@@ -189,7 +189,7 @@ test "input output pairs" {
                 var gd_writer: GdWriter = .init(.{
                     .writer = writer,
                     .allocator = allocator,
-                    .indent_config = .{
+                    .whitespace_config = .{
                         .style = indent_style,
                     },
                 });
@@ -215,7 +215,7 @@ const cli = @import("cli");
 
 const CliConfig = @import("CliConfig.zig");
 const GdWriter = @import("GdWriter.zig");
-const IndentConfig = @import("IndentConfig.zig");
+const WhitespaceConfig = @import("WhitespaceConfig.zig");
 
 const formatter = @import("formatter.zig");
 const logging = @import("logging.zig");


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

This PR implements Phase 1 of the whitespace configuration refactoring as outlined in Issue #11. This is a pure renaming/refactoring effort with no functional changes to the formatter behavior.

## Changes Made

### File Renames
- `src/IndentConfig.zig` → `src/WhitespaceConfig.zig`

### Struct and Method Updates
- Struct name: `IndentConfig` → `WhitespaceConfig`
- Method name: `fromCliConfig` → `fromCli`
- Variable names: `indent_config` → `whitespace_config`
- Field names in Options structs updated accordingly

### Files Modified
- `/home/sh/Projects/gd-pretty/src/WhitespaceConfig.zig` (renamed from IndentConfig.zig)
- `/home/sh/Projects/gd-pretty/src/GdWriter.zig` - Updated import and variable references
- `/home/sh/Projects/gd-pretty/src/IndentWriter.zig` - Updated import and variable references  
- `/home/sh/Projects/gd-pretty/src/main.zig` - Updated import and variable references

## Verification

- ✅ All tests pass: `zig build test`
- ✅ Code compiles without errors: `zig build`
- ✅ No functional changes - this is pure refactoring
- ✅ All import statements updated to reference new names
- ✅ All struct and method names consistently updated

## What's Next

This is Phase 1 only. Future phases will:
- Add new whitespace configuration options
- Consolidate whitespace logic
- Enhance formatting capabilities

Closes #11

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)